### PR TITLE
chore(ci): use jessie images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,7 @@ jobs:
   test:
     docker:
       # specify the version you desire here
-      - image: circleci/node:9
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
+      - image: circleci/node:9-stretch
 
     working_directory: ~/repo
 
@@ -39,12 +34,7 @@ jobs:
   publish-translations:
     docker:
       # specify the version you desire here
-      - image: circleci/node:9
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
+      - image: circleci/node:9-stretch
 
     working_directory: ~/repo
 


### PR DESCRIPTION
stretch images were removed from all debian mirrors